### PR TITLE
secrets.ymlをignoreしない

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,4 @@
 /yarn-error.log
 
 .byebug_history
-config/secrets.yml
 public/uploads

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,0 +1,22 @@
+# Be sure to restart your server when you modify this file.
+
+# Your secret key is used for verifying the integrity of signed cookies.
+# If you change this key, all old signed cookies will become invalid!
+
+# Make sure the secret is at least 30 characters and all random,
+# no regular words or you'll be exposed to dictionary attacks.
+# You can use `rake secret` to generate a secure secret key.
+
+# Make sure the secrets in this file are kept private
+# if you're sharing your code publicly.
+
+development:
+  secret_key_base: 1f8ebad38225d260661f4b9047b0d754fcb4f5f928c678178c6190d935215ee3c1869add3a95737972b0b8bb05c1440326a81e9ac6b7416272657d67a774287e
+
+test:
+  secret_key_base: 1287fcc03a8e5880d1e45589aa34d64be7c2b25be03c915a2f5e455304d89ea97cd1ff6b6d5b2bb0a1017b961495fe6edb2e52f0e0f74302fcd4aab78558d27f
+
+# Do not keep production secrets in the repository,
+# instead read values from the environment.
+production:
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>


### PR DESCRIPTION
# what 
.gitignoreからsecrets.ymlを外した

# why
secrets.ymlがないとHerokuのデプロイ時、secret_key_baseがないという
エラーで失敗してしまう。

APIの開発用にデプロイをしておきたいため解消する。

なお、secret_key_baseはクッキーの読み書きの時の暗号化に使われるものらしい。
そのためdevelopmentとtest用のキーは万が一漏れても危険性のないものと
判断しています。